### PR TITLE
bpo-44730: Add handling of generator functions

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1311,6 +1311,8 @@ class _patch(object):
             return self.decorate_class(func)
         if inspect.iscoroutinefunction(func):
             return self.decorate_async_callable(func)
+        if inspect.isgeneratorfunction(func):
+            return self.decorate_generator_callable(func)
         return self.decorate_callable(func)
 
 
@@ -1343,8 +1345,25 @@ class _patch(object):
             yield (args, keywargs)
 
 
+    def decorate_generator_callable(self, func):
+        # NB. Keep the method in sync with decorate_async_callable() and decorate_callable()
+        if hasattr(func, 'patchings'):
+            func.patchings.append(self)
+            return func
+
+        @wraps(func)
+        def patched(*args, **keywargs):
+            with self.decoration_helper(patched,
+                                        args,
+                                        keywargs) as (newargs, newkeywargs):
+                yield from func(*newargs, **newkeywargs)
+
+        patched.patchings = [self]
+        return patched
+
+
     def decorate_callable(self, func):
-        # NB. Keep the method in sync with decorate_async_callable()
+        # NB. Keep the method in sync with decorate_async_callable() and decorate_generator_callable()
         if hasattr(func, 'patchings'):
             func.patchings.append(self)
             return func
@@ -1361,7 +1380,7 @@ class _patch(object):
 
 
     def decorate_async_callable(self, func):
-        # NB. Keep the method in sync with decorate_callable()
+        # NB. Keep the method in sync with decorate_callable() and decorate_generator_callable()
         if hasattr(func, 'patchings'):
             func.patchings.append(self)
             return func


### PR DESCRIPTION
Previously generator functions were changed by patches applied as decorators, ending up as non-generator functions (co_flags changed from 99 to 31). Patches were not applied properly in these generator functions.

This PR addresses this by adding a simple switch in mock.py to handle generator functions cleanly.
